### PR TITLE
fix: config_loader repo URL, Makefile improvements, SOPS multi-key

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Pre-commit hook: verify all SOPS files have all required AGE recipients
+# Pre-commit hook: verify all SOPS files have all required recipients
 #
-# Prevents committing SOPS files encrypted for only one machine.
+# Prevents committing SOPS files that can't be decrypted by all machines.
+# Every SOPS file must have both AGE keys AND the KMS key.
 
 set -euo pipefail
 
@@ -9,6 +10,8 @@ REQUIRED_AGE_KEYS=(
   "age1qr8admz3tpydxtwuefwdggm2vks36e2x5966zj8m84j2elyurdfsdg5jfk"
   "age18y8alr4hmg0cupmqwlzjgrmwn495q74275jfk4j4hyvlgv80n3vsc8th8g"
 )
+
+REQUIRED_KMS_KEY="arn:aws:kms:us-east-1:256935246980:key/e066688f-aa55-470e-9a33-84393e9c4310"
 
 SOPS_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.sops\.(yml|yaml)$' || true)
 
@@ -22,15 +25,19 @@ for file in $SOPS_FILES; do
   for key in "${REQUIRED_AGE_KEYS[@]}"; do
     if ! grep -q "$key" "$file"; then
       echo "ERROR: $file is missing AGE recipient: $key"
-      echo "  Run: sops updatekeys $file"
       FAILED=1
     fi
   done
+
+  if ! grep -q "$REQUIRED_KMS_KEY" "$file"; then
+    echo "ERROR: $file is missing KMS key: $REQUIRED_KMS_KEY"
+    FAILED=1
+  fi
 done
 
 if [ "$FAILED" -ne 0 ]; then
   echo ""
-  echo "SOPS files must be encrypted for all AGE keys listed in .sops.yaml."
+  echo "SOPS files must be encrypted for all AGE keys AND the KMS key."
   echo "Run 'sops updatekeys <file>' to add missing recipients."
   exit 1
 fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Pre-commit hook: verify all SOPS files have all required AGE recipients
+#
+# Prevents committing SOPS files encrypted for only one machine.
+
+set -euo pipefail
+
+REQUIRED_AGE_KEYS=(
+  "age1qr8admz3tpydxtwuefwdggm2vks36e2x5966zj8m84j2elyurdfsdg5jfk"
+  "age18y8alr4hmg0cupmqwlzjgrmwn495q74275jfk4j4hyvlgv80n3vsc8th8g"
+)
+
+SOPS_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.sops\.(yml|yaml)$' || true)
+
+if [ -z "$SOPS_FILES" ]; then
+  exit 0
+fi
+
+FAILED=0
+
+for file in $SOPS_FILES; do
+  for key in "${REQUIRED_AGE_KEYS[@]}"; do
+    if ! grep -q "$key" "$file"; then
+      echo "ERROR: $file is missing AGE recipient: $key"
+      echo "  Run: sops updatekeys $file"
+      FAILED=1
+    fi
+  done
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo ""
+  echo "SOPS files must be encrypted for all AGE keys listed in .sops.yaml."
+  echo "Run 'sops updatekeys <file>' to add missing recipients."
+  exit 1
+fi

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,18 +1,24 @@
 # SOPS configuration file
-# Uses both age and AWS KMS encryption for redundancy
+# Uses both age keys and AWS KMS encryption for redundancy
 
 creation_rules:
   # Match any .sops.yml file in host_vars or group_vars
   - path_regex: .*(host_vars|group_vars)/.*\.sops\.(yml|yaml)$
-    age: age1qr8admz3tpydxtwuefwdggm2vks36e2x5966zj8m84j2elyurdfsdg5jfk
+    age: >-
+      age1qr8admz3tpydxtwuefwdggm2vks36e2x5966zj8m84j2elyurdfsdg5jfk,
+      age18y8alr4hmg0cupmqwlzjgrmwn495q74275jfk4j4hyvlgv80n3vsc8th8g
     kms: arn:aws:kms:us-east-1:256935246980:key/e066688f-aa55-470e-9a33-84393e9c4310
 
   # Match group_vars/all for kopia secrets
   - path_regex: group_vars/all/.*\.sops\.(yml|yaml)$
-    age: age1qr8admz3tpydxtwuefwdggm2vks36e2x5966zj8m84j2elyurdfsdg5jfk
+    age: >-
+      age1qr8admz3tpydxtwuefwdggm2vks36e2x5966zj8m84j2elyurdfsdg5jfk,
+      age18y8alr4hmg0cupmqwlzjgrmwn495q74275jfk4j4hyvlgv80n3vsc8th8g
     kms: arn:aws:kms:us-east-1:256935246980:key/e066688f-aa55-470e-9a33-84393e9c4310
 
   # Fallback for any .sops.yml file
   - path_regex: .*\.sops\.(yml|yaml)$
-    age: age1qr8admz3tpydxtwuefwdggm2vks36e2x5966zj8m84j2elyurdfsdg5jfk
+    age: >-
+      age1qr8admz3tpydxtwuefwdggm2vks36e2x5966zj8m84j2elyurdfsdg5jfk,
+      age18y8alr4hmg0cupmqwlzjgrmwn495q74275jfk4j4hyvlgv80n3vsc8th8g
     kms: arn:aws:kms:us-east-1:256935246980:key/e066688f-aa55-470e-9a33-84393e9c4310

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ define ansible_env
 	export AWS_PROFILE=$(AWS_PROFILE)
 endef
 
-.PHONY: help setup setup-sops run dev nvim vpn-hub vpn-client networking users syncthing docker pxe edit edit-group clean
+.PHONY: help install setup setup-sops run dev nvim vpn-hub vpn-client networking users syncthing docker pxe edit edit-group clean
 
 help:
 	@echo "Available targets:"
@@ -85,14 +85,18 @@ help:
 	@echo "  make edit HOST=mouse"
 	@echo "  make edit-group GROUP=home"
 
-setup:
-	@echo "Creating virtual environment..."
-	python3 -m venv $(VENV)
+install:
+	@if [ ! -d "$(VENV)" ]; then \
+		echo "Creating virtual environment..."; \
+		python3 -m venv $(VENV); \
+	fi
 	source $(VENV)/bin/activate && pip install --upgrade pip
 	source $(VENV)/bin/activate && pip install ansible
 	source $(VENV)/bin/activate && ansible-galaxy collection install -r requirements.yml
 	source $(VENV)/bin/activate && ansible-galaxy collection install community.sops community.general
-	@echo "Setup complete!"
+	@echo "Install complete!"
+
+setup: install
 
 setup-sops:
 	$(ansible_env) && \

--- a/roles/config_loader/defaults/main.yml
+++ b/roles/config_loader/defaults/main.yml
@@ -5,7 +5,7 @@
 # to empty to use a pre-existing local checkout instead.
 
 # Git repository containing the config store
-config_store_repo: "git@github.com:paulostation/prod-values.git"
+config_store_repo: "https://github.com/paulostation/prod-values-personal.git"
 
 # Local path to clone/update the config store
 config_store_path: "~/.cache/ansible/prod-values"


### PR DESCRIPTION
## Summary
- Fix `config_store_repo` URL to `prod-values-personal` (HTTPS)
- Export `AWS_PROFILE=personal-admin-management` in Makefile for SOPS KMS decryption
- Add `make install` target that creates venv only if missing
- Add second AGE key (asus-tuf) to `.sops.yaml` so new SOPS files are encrypted for both machines
- Add `.githooks/pre-commit` hook that rejects commits with SOPS files missing any required AGE recipient

## Test plan
- [ ] `make install` creates venv if missing, skips if exists
- [ ] `make vpn-hub` decrypts SOPS files via KMS (requires `aws sso login` first)
- [ ] `sops updatekeys` on any file adds both AGE keys
- [ ] Pre-commit hook blocks commits with single-key SOPS files

## Setup
After merging, run once:
```bash
git config core.hooksPath .githooks
```