### PR TITLE
fix(config_loader): correct repo URL to prod-values

### DIFF
--- a/roles/config_loader/defaults/main.yml
+++ b/roles/config_loader/defaults/main.yml
@@ -5,7 +5,7 @@
 # to empty to use a pre-existing local checkout instead.
 
 # Git repository containing the config store
-config_store_repo: "https://github.com/paulostation/prod-values-personal.git"
+config_store_repo: "https://github.com/paulostation/prod-values.git"
 
 # Local path to clone/update the config store
 config_store_path: "~/.cache/ansible/prod-values"


### PR DESCRIPTION
## Summary
- Fix `config_store_repo` from `prod-values-personal` to `prod-values` (the duplicate repo is being deleted)

## Context
Follow-up to PR #52. The agent accidentally created a duplicate repo during the initial implementation.