### PR TITLE
fix(config_loader): correct repo URL and pin version to main

### DIFF
--- a/roles/config_loader/defaults/main.yml
+++ b/roles/config_loader/defaults/main.yml
@@ -5,13 +5,13 @@
 # to empty to use a pre-existing local checkout instead.
 
 # Git repository containing the config store
-config_store_repo: "https://github.com/paulostation/prod-values-personal.git"
+config_store_repo: "https://github.com/paulostation/prod-values.git"
 
 # Local path to clone/update the config store
 config_store_path: "~/.cache/ansible/prod-values"
 
 # Git branch/tag/commit to checkout
-config_store_version: HEAD
+config_store_version: main
 
 # Environment tier directory name
 config_environment: production


### PR DESCRIPTION
## Summary
- Fix `config_store_repo` URL from `prod-values-personal.git` to `prod-values.git` (matching the actual GitHub repo name)
- Pin `config_store_version` from `HEAD` to `main` — `HEAD` resolved to whatever branch the local cache had checked out, causing stale config deployments when the cache was stuck on a feature branch

## Context
This caused the vpn-hub playbook to deploy stale WireGuard configs — new peers added to prod-values were never picked up because the cache at `~/.cache/ansible/prod-values` was checked out on `feat/dns-records` and `version: HEAD` kept it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)