### PR TITLE
fix(lokinet): make playbook portable, reliable, and keyless

### DIFF
--- a/playbooks/install_lokinet.yml
+++ b/playbooks/install_lokinet.yml
@@ -17,7 +17,7 @@
 
     - name: Set ansible_ssh_common_args to disable host key checking for dynamically added hosts
       set_fact:
-        ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
 
   roles:
 

--- a/playbooks/lokinet-client.yml
+++ b/playbooks/lokinet-client.yml
@@ -9,7 +9,7 @@
     cleanup: yes
     # vm_name: "{{ vm_name }}"
     net: default
-    ssh_pub_key: "/home/paulosf/.ssh/id_rsa.pub"
+    ssh_pub_key: "{{ lookup('env', 'HOME') }}/.ssh/id_ed25519.pub"
 
   pre_tasks:
     - include_role:
@@ -26,7 +26,6 @@
         vm_ram_mb: 4096
         cleanup_tmp: "{{ cleanup }}"
         ssh_key: "{{ ssh_pub_key }}"
-        install_desktop: true
         private_network_only: true
 
     - name: Validate if the VM has an IP address

--- a/playbooks/lokinet-gw.yml
+++ b/playbooks/lokinet-gw.yml
@@ -16,7 +16,7 @@
     vm_name: lokinet-gw-{{ vm_group_suffix }}
     client_vm_name: lokinet-client-{{ vm_group_suffix }}
     private_network_name: loki-network-{{ vm_group_suffix }}
-    ssh_pub_key: "/home/paulosf/.ssh/id_rsa.pub"
+    ssh_pub_key: "{{ lookup('env', 'HOME') }}/.ssh/id_ed25519.pub"
 
   pre_tasks:
     - include_role:
@@ -53,22 +53,20 @@
         primary_network_interface: ens3
         secondary_network_interface: ens6
         lokinet_is_an_upgrade: true
-        # lokinet_exit_node_url: exit.loki
-        lokinet_exit_node_url: x8ip9ajto9heyfbm5hrzh8eunwaqi8rrbxdhezf3gh9nyf88peqo.loki
-        lokinet_exit_node_token: f7c168ed3f
+        lokinet_exit_node_url: exit.loki
       args: 
         host_name: '{{ vm_name }}'
         #dhcp_addr: '{{ dhcp_addr.stdout }}'
     
     - name: Set ansible_ssh_common_args to disable host key checking for dynamically added hosts
       set_fact:
-        ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+        ansible_ssh_common_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
 
     - name: Validate if ssh is up
-      shell: ssh -T ubuntu@{{ dhcp_addr.stdout }} exit
+      shell: ssh -T -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o BatchMode=yes -o ConnectTimeout=5 ubuntu@{{ dhcp_addr.stdout }} exit
       register: ssh_success
       until: "ssh_success is not failed"
-      retries: 10
+      retries: 30
       delay: 10
 
 

--- a/roles/kvm_provision/templates/cloud-init-user-data.j2
+++ b/roles/kvm_provision/templates/cloud-init-user-data.j2
@@ -11,8 +11,7 @@ users:
     sudo: ALL=(ALL) NOPASSWD:ALL
     lock_passwd: false
     ssh-authorized-keys:
-      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJxduSIrlr3Me8KXxoEETJijsvH9UpwzqJ4ESHMb2DL4"
-      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMCVQtAb9abo2PZPpkkk3MyPCXK7GjZj3ZyZO5HawQVT"
+      - "{{ lookup('file', ssh_key) }}"
 chpasswd:
   list: |
     ubuntu:$6$EvI5i.9CtcWPvo$KB2S7GB9VBgpUDNG4wDju5PRsDmP3x/xLfGcnLlnDYfKV4MLcH77x80RcfKLxOJCGbNBALh1YgRJLV9BKIMZm1

--- a/roles/lokinet/defaults/main.yml
+++ b/roles/lokinet/defaults/main.yml
@@ -1,7 +1,6 @@
 lokinet_standalone_install: false
 install_lokinet_vpn_manager: true
-lokinet_exit_node_url: x8ip9ajto9heyfbm5hrzh8eunwaqi8rrbxdhezf3gh9nyf88peqo.loki
-lokinet_exit_node_token: d1a11bfac1
+lokinet_exit_node_url: exit.loki
 primary_network_interface: eth0
 secondary_network_interface: wlan0
 should_reboot: false


### PR DESCRIPTION
## Summary

- Makes the `lokinet-gw` / `lokinet-client` playbooks runnable on any developer's machine (previously hardcoded to the original author's home dir and a private ssh key).
- Fixes several hangs/failures that surfaced when re-running against a fresh host: the cloud-init template ignored the injected `ssh_key`, the post-provision `ssh -T` probe hung on the host-key prompt, and the default exit node was a private token-gated instance.
- Leaves the client-side design gaps documented as follow-ups; this PR is scoped to portability and reliability of the gateway path.

## What changed

- `roles/kvm_provision/templates/cloud-init-user-data.j2` — replace two hardcoded `ssh-ed25519 …` lines with `{{ lookup('file', ssh_key) }}`. The `ssh_key` var was already being passed through but silently ignored.
- `playbooks/lokinet-gw.yml`, `playbooks/lokinet-client.yml` — default `ssh_pub_key` to `{{ lookup('env', 'HOME') }}/.ssh/id_ed25519.pub` (was `/home/paulosf/.ssh/id_rsa.pub`).
- `playbooks/lokinet-gw.yml` — harden the raw `shell: ssh -T ubuntu@…` probe with `StrictHostKeyChecking=no`, `UserKnownHostsFile=/dev/null`, `BatchMode=yes`, `ConnectTimeout=5`; bump retries 10→30 since cloud-init on first boot takes >100s.
- `playbooks/install_lokinet.yml`, `playbooks/lokinet-gw.yml` — append `UserKnownHostsFile=/dev/null` to `ansible_ssh_common_args` so rebuilds don't pollute the operator's known_hosts.
- `playbooks/lokinet-client.yml` — drop `install_desktop: true` (30+ min of ubuntu-desktop/tor-browser/telegram traffic through the NATted gw for a VPN-client VM).
- `roles/lokinet/defaults/main.yml` and `playbooks/lokinet-gw.yml` add_host args — default to the free public `exit.loki` instead of the hardcoded private exit (`x8ip9ajto9he…ge9nyf88peqo.loki` / token `d1a11bfac1`).

## Why these were bugs, not preferences

- **Hardcoded cloud-init keys**: the `ssh_key` var was wired into `kvm_provision` and passed down, but the Jinja template never read it. Every VM came up with the original author's ed25519 keys authorized, so no one else could SSH in. This made the whole flow non-functional on any other workstation.
- **`ssh -T` hang**: `ansible_ssh_common_args` only affects Ansible's own SSH, not a `shell: ssh …` subprocess. Without `StrictHostKeyChecking=no` on the raw invocation, the first probe blocks on `Are you sure you want to continue connecting (yes/no/[fingerprint])?` forever. The retry loop never advances.
- **Hardcoded /home/paulosf path**: playbook errored at the `copy:` step before even reaching provisioning.

## Known follow-ups (not in this PR)

These are real design gaps for getting a working gateway↔client pair; they warrant separate PRs:

- `roles/kvm_provision/templates/cloud-init-net-config.yaml.j2` hardcodes `ens6: 10.17.0.9/24` for both gateway and client VMs — IP collision on the private bridge. Needs per-role/per-host templating.
- `loki-network-<suffix>` is defined as a plain bridge with no DHCP range. A single-NIC client cannot acquire an address. Either add `<dhcp><range …/></dhcp>` to `libvirt-private-network.xml.j2` or provision the client with a dual-NIC topology.
- `playbooks/lokinet-gw.yml` imports `install_lokinet.yml` for the gateway VM but never for the client VM, so even a well-addressed client comes up with no lokinet installed.
- The playbook orchestrates VM provisioning + in-VM config in one shot. Splitting the two (provision → wait-ready → configure) would make re-runs and individual step recovery much easier.

## Test plan

- [x] Ran on pc-do-b (Ubuntu 24.04, libvirt 10.0.0, qemu 8.2.2) end-to-end for the gateway path:
  `ansible-playbook -i /tmp/lokinet-inventory.yml playbooks/install_lokinet.yml -e target_host=lokinet-gw-51 -e config_store_repo= -e config_store_path=`
  → `PLAY RECAP: ok=39 changed=23 failed=0`
- [x] Verified `/etc/cloud/...` in the VM contains the caller's ed25519 pub, not the old hardcoded ones.
- [x] Verified `systemctl cat lokinet-vpn.service` and `lokinet-vpn-manager.service` are installed and enabled on the VM.
- [ ] Not tested: the client-VM flow (blocked on the follow-up items above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)